### PR TITLE
webframe, cleanup

### DIFF
--- a/default/index.html
+++ b/default/index.html
@@ -3,22 +3,31 @@
   <head>
     <style type="text/css">
       body,html{
+        font-family: Arial, Helvetica, sans-serif;
         height: 100%;
         width: 100%;
         margin: 0;
         padding: 0;
         overflow: hidden;
       }
-      h1{
+      body {
         color: #fff;
-        margin: 50px;
+        font-size: 4vmax;
+        display: flex;
+        flex-direction: column;
+        align-content: center;
+        justify-content: center;
+        text-align: center;
+        text-transform: uppercase;
       }
     </style>
     <script type="text/javascript">
-      oak.ready()
+      document.addEventListener( "DOMContentLoaded", function () {        
+        oak.ready()
+      }, false)
     </script>
   </head>
   <body>
-    <h1>Oak default app</h1>
+    <div>oak default app</div>
   </body>
 </html>

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -1,7 +1,8 @@
-const {
+const { 
   remote: { getGlobal: _getGlobal },
-  ipcRenderer: renderer
+  ipcRenderer: renderer, webFrame
 } = require('electron')
+
 const qs = require('querystring')
 const url = require('url')
 const { EventEmitter2: _ee } = require('eventemitter2')
@@ -53,21 +54,16 @@ _ee.prototype.focus = function () {
 
 _ee.prototype.id = qs.parse(url.parse(window.location.href).query).oak_id
 
+_ee.prototype.webFrame = webFrame
+
 const _oak = new _ee({
   wildcard: true,
-  maxListeners: 20,
+  maxListeners: 100,
   newListener: false
 })
 
 renderer.emit = function (e, ee, data) {
   _oak.emit(e, data)
-}
-
-window.onerror = function (msg, url, line) {
-  return _oak.send('logger.error', {
-    event: msg,
-    err: new Error(`${url}: ${line}`)
-  })
 }
 
 window.oak = _oak

--- a/lib/window.js
+++ b/lib/window.js
@@ -114,10 +114,6 @@ class DisplayService extends EventEmitter2 {
       _this.send(this.event, ...arguments)
     })
 
-    core.message.on(`${_this.id}.**`, function () {
-      _this.send(this.event, ...arguments)
-    })
-
     this.loadPage()
 
     return this


### PR DESCRIPTION
client:
* `electron.webFrame` exposed on `oak`
* error listener removed
* upped max event listeners on `window.oak`
* minor default page cleanup

main:
* `id.*` event listener removed 